### PR TITLE
Add Modal for Modifying or Deleting Existing Gold Entries

### DIFF
--- a/apertium-regtest.py
+++ b/apertium-regtest.py
@@ -834,7 +834,7 @@ def start_server(port, page_size=25):
     print('Open http://localhost:%d in your browser' % port)
     with BigQueueServer(('', port), handle) as httpd:
         try:
-   	        httpd.serve_forever()
+            httpd.serve_forever()
         except KeyboardInterrupt:
             print('')
             # the exception raised by sys.exit() gets caught by the

--- a/static/regtest.css
+++ b/static/regtest.css
@@ -73,6 +73,22 @@ ul.rt-gold:before {
     font-weight: bold;
 }
 
+.rt-gold li {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 5px 15px; /* Adjust padding as needed */
+}
+
+.rt-gold li .btn-container {
+    display: flex;
+    gap: 10px; /* Space between the buttons */
+}
+
+.rt-gold .btn-container .btn {
+    margin: 0; /* Remove default margins */
+}
+
 input.rt-gold-input-box {
     width: 75%;
 }

--- a/static/regtest.js
+++ b/static/regtest.js
@@ -450,7 +450,9 @@ function btn_gold_replace() {
 	let s = tr.find('.nav-link.active').text();
 	let gs = [tr.find('.rt-output.active').attr('data-output')];
 	let tid = toast('Replacing Gold', 'Corpus '+c+' sentence '+h+' step '+s);
-	post({a: 'gold', c: c, h: h, s: s, gs: JSON.stringify(gs)}).done(function(rv) { $(tid).toast('hide'); cb_accept(rv); });
+	if (confirm('Are you sure you want to save the changes?')) {
+		post({a: 'gold', c: c, h: h, s: s, gs: JSON.stringify(gs)}).done(function(rv) { $(tid).toast('hide'); cb_accept(rv); });
+	}
 }
 
 function btn_gold_add() {
@@ -465,7 +467,9 @@ function btn_gold_add() {
 	}
 	gs.push(tr.find('.rt-output.active').attr('data-output'));
 	let tid = toast('Adding Gold', 'Corpus '+c+' sentence '+h+' step '+s);
-	post({a: 'gold', c: c, h: h, s: s, gs: JSON.stringify(gs)}).done(function(rv) { $(tid).toast('hide'); cb_accept(rv); });
+	if (confirm('Are you sure you want to save the changes?')) {
+		post({a: 'gold', c: c, h: h, s: s, gs: JSON.stringify(gs)}).done(function(rv) { $(tid).toast('hide'); cb_accept(rv); });
+	}
 }
 
 function btn_gold_manual() {

--- a/static/regtest.js
+++ b/static/regtest.js
@@ -474,13 +474,6 @@ function btn_gold_manual() {
 	tr.find('.rt-gold-input').show().find('input').val(val);
 }
 
-function make_gold_list(golds) {
-	let ul = '<ul class="list-group rt-gold">';
-	ul += golds.map(g => '<li class="list-group-item">'+esc_html(g)+'</li>').join('');
-	ul += '</ul>';
-	return ul;
-}
-
 function btn_gold_manual_accept() {
 	let tr = $(this).closest('tr');
 	let c = tr.attr('data-corp');

--- a/static/regtest.js
+++ b/static/regtest.js
@@ -774,25 +774,25 @@ function cb_init(rv) {
 	$('.btnFilterGold').off().click(btn_filter_gold);
 }
 
-function btn_gold_edit() {
-    let tr = $(this).closest('tr'); 
-    let c = tr.attr('data-corp'); 
+function btn_gold_edit(goldText) {
+    let tr = $(this).closest('tr');
+    let c = tr.attr('data-corp');
     let h = tr.attr('data-hash');
-    let s = tr.find('.nav-link.active').text(); 
+    let s = tr.find('.nav-link.active').text();
     let gs = [];
     let gold = state[c].cmds[state[c].cmds.length - 1].gold;
 
     if (gold.hasOwnProperty(h)) {
-        gs = gold[h]; 
+        gs = gold[h];
     }
 
-    let currentGold = $(this).text(); 
-    let newGold = prompt('Edit Gold:', currentGold); 
+    let currentGold = goldText; 
+    let newGold = prompt('Edit Gold:', currentGold);
 
     if (newGold !== null && newGold.trim() !== '') {
-        let index = gs.indexOf(currentGold); 
+        let index = gs.indexOf(currentGold);
         if (index !== -1) {
-            gs[index] = newGold; 
+            gs[index] = newGold;
         }
         let tid = toast('Editing Gold', 'Corpus ' + c + ' sentence ' + h + ' step ' + s);
         post({ a: 'gold', c: c, h: h, s: s, gs: JSON.stringify(gs) }).done(function (rv) {
@@ -802,30 +802,50 @@ function btn_gold_edit() {
     }
 }
 
+
 function btn_gold_delete() {
-    let tr = $(this).closest('tr'); 
-    let c = tr.attr('data-corp'); 
-    let h = tr.attr('data-hash'); 
-    let s = tr.find('.nav-link.active').text(); 
+    let li = $(this).closest('li'); 
+    let tr = li.closest('tr'); 
+    let c = tr.attr('data-corp');
+    let h = tr.attr('data-hash');
+    let s = tr.find('.nav-link.active').text();
     let gs = [];
-    let gold = state[c].cmds[state[c].cmds.length - 1].gold; 
+    let gold = state[c].cmds[state[c].cmds.length-1].gold;
 
     if (gold.hasOwnProperty(h)) {
-        gs = gold[h]; 
+        gs = gold[h];
     }
 
-    let currentGold = $(this).text(); 
-    if (confirm('Are you sure you want to delete this gold: ' + currentGold + '?')) {
-        let index = gs.indexOf(currentGold); 
-        if (index !== -1) {
-            gs.splice(index, 1); 
-        }
-        let tid = toast('Deleting Gold', 'Corpus ' + c + ' sentence ' + h + ' step ' + s);
-        post({ a: 'gold', c: c, h: h, s: s, gs: JSON.stringify(gs) }).done(function (rv) {
-            $(tid).toast('hide');
-            cb_accept(rv);
-        });
+    let currentGold = li.text().trim(); 
+    let index = gs.indexOf(currentGold);
+    if (index !== -1) {
+        gs.splice(index, 1); 
     }
+
+    let tid = toast('Deleting Gold', 'Corpus ' + c + ' sentence ' + h + ' step ' + s);
+    post({ a: 'gold', c: c, h: h, s: s, gs: JSON.stringify(gs) }).done(function (rv) {
+        $(tid).toast('hide');
+        cb_accept(rv);
+    });
+
+    li.remove();
+}
+
+
+function make_gold_list(golds) {
+    let ul = '<ul class="list-group rt-gold">';
+    ul += golds.map(g => {
+        return `
+            <li class="list-group-item d-flex justify-content-between align-items-center">
+                <span class="gold-text">${esc_html(g)}</span>
+                <div class="btn-container">
+                    <button type="button" class="btn btn-sm btn-outline-info my-2 btnEditGold">Edit</button>
+                    <button type="button" class="btn btn-sm btn-outline-danger my-2 btnDeleteGold">Delete</button>
+                </div>
+            </li>`;
+    }).join('');
+    ul += '</ul>';
+    return ul;
 }
 
 
@@ -841,15 +861,15 @@ function cb_load(rv) {
 
 	state = rv.state;
 
-	$(document).on('click', '.rt-gold li', function () {
-		let $goldItem = $(this);
-		let action = prompt('Choose Action: (edit/delete)', 'edit');
-		if (action === 'edit') {
-			btn_gold_edit.call($goldItem);
-		} else if (action === 'delete') {
-			btn_gold_delete.call($goldItem);
-		}
+	$(document).on('click', '.rt-gold .btnEditGold', function () {
+		let li = $(this).closest('li');  
+		let goldText = li.find('.gold-text').text();  
+		btn_gold_edit.call(this, goldText);  
 	});
+	
+	$(document).on('click', '.rt-gold .btnDeleteGold', function () {
+		btn_gold_delete.call(this); 
+	});	
 
 
 	let pages = '';

--- a/static/regtest.js
+++ b/static/regtest.js
@@ -864,7 +864,6 @@ function cb_load(rv) {
 		btn_gold_delete.call(this); 
 	});	
 
-
 	let pages = '';
 	if (state._pages > 1) {
 		pages += '<ul class="pagination"><li class="page-item"><a class="page-link rt-page rt-page-prev" href="#" data-which="prev">&laquo;</a></li>';

--- a/static/regtest.js
+++ b/static/regtest.js
@@ -450,9 +450,7 @@ function btn_gold_replace() {
 	let s = tr.find('.nav-link.active').text();
 	let gs = [tr.find('.rt-output.active').attr('data-output')];
 	let tid = toast('Replacing Gold', 'Corpus '+c+' sentence '+h+' step '+s);
-	if (confirm('Are you sure you want to save the changes?')) {
-		post({a: 'gold', c: c, h: h, s: s, gs: JSON.stringify(gs)}).done(function(rv) { $(tid).toast('hide'); cb_accept(rv); });
-	}
+	post({a: 'gold', c: c, h: h, s: s, gs: JSON.stringify(gs)}).done(function(rv) { $(tid).toast('hide'); cb_accept(rv); });
 }
 
 function btn_gold_add() {
@@ -467,9 +465,7 @@ function btn_gold_add() {
 	}
 	gs.push(tr.find('.rt-output.active').attr('data-output'));
 	let tid = toast('Adding Gold', 'Corpus '+c+' sentence '+h+' step '+s);
-	if (confirm('Are you sure you want to save the changes?')) {
-		post({a: 'gold', c: c, h: h, s: s, gs: JSON.stringify(gs)}).done(function(rv) { $(tid).toast('hide'); cb_accept(rv); });
-	}
+	post({a: 'gold', c: c, h: h, s: s, gs: JSON.stringify(gs)}).done(function(rv) { $(tid).toast('hide'); cb_accept(rv); });
 }
 
 function btn_gold_manual() {
@@ -778,6 +774,61 @@ function cb_init(rv) {
 	$('.btnFilterGold').off().click(btn_filter_gold);
 }
 
+function btn_gold_edit() {
+    let tr = $(this).closest('tr'); 
+    let c = tr.attr('data-corp'); 
+    let h = tr.attr('data-hash');
+    let s = tr.find('.nav-link.active').text(); 
+    let gs = [];
+    let gold = state[c].cmds[state[c].cmds.length - 1].gold;
+
+    if (gold.hasOwnProperty(h)) {
+        gs = gold[h]; 
+    }
+
+    let currentGold = $(this).text(); 
+    let newGold = prompt('Edit Gold:', currentGold); 
+
+    if (newGold !== null && newGold.trim() !== '') {
+        let index = gs.indexOf(currentGold); 
+        if (index !== -1) {
+            gs[index] = newGold; 
+        }
+        let tid = toast('Editing Gold', 'Corpus ' + c + ' sentence ' + h + ' step ' + s);
+        post({ a: 'gold', c: c, h: h, s: s, gs: JSON.stringify(gs) }).done(function (rv) {
+            $(tid).toast('hide');
+            cb_accept(rv);
+        });
+    }
+}
+
+function btn_gold_delete() {
+    let tr = $(this).closest('tr'); 
+    let c = tr.attr('data-corp'); 
+    let h = tr.attr('data-hash'); 
+    let s = tr.find('.nav-link.active').text(); 
+    let gs = [];
+    let gold = state[c].cmds[state[c].cmds.length - 1].gold; 
+
+    if (gold.hasOwnProperty(h)) {
+        gs = gold[h]; 
+    }
+
+    let currentGold = $(this).text(); 
+    if (confirm('Are you sure you want to delete this gold: ' + currentGold + '?')) {
+        let index = gs.indexOf(currentGold); 
+        if (index !== -1) {
+            gs.splice(index, 1); 
+        }
+        let tid = toast('Deleting Gold', 'Corpus ' + c + ' sentence ' + h + ' step ' + s);
+        post({ a: 'gold', c: c, h: h, s: s, gs: JSON.stringify(gs) }).done(function (rv) {
+            $(tid).toast('hide');
+            cb_accept(rv);
+        });
+    }
+}
+
+
 function cb_load(rv) {
 	$('.rt-added,.rt-deleted,.rt-add-del-warn,.rt-deleted').hide();
 	$('#rt-added,#rt-deleted').find('tbody').remove();
@@ -789,6 +840,17 @@ function cb_load(rv) {
 	let nd_corps = {};
 
 	state = rv.state;
+
+	$(document).on('click', '.rt-gold li', function () {
+		let $goldItem = $(this);
+		let action = prompt('Choose Action: (edit/delete)', 'edit');
+		if (action === 'edit') {
+			btn_gold_edit.call($goldItem);
+		} else if (action === 'delete') {
+			btn_gold_delete.call($goldItem);
+		}
+	});
+
 
 	let pages = '';
 	if (state._pages > 1) {


### PR DESCRIPTION
#### Overview
This PR introduces functionality to edit and delete gold entries within the corpus. Users can now interact with individual gold entries and either modify or remove them as needed.

#### Changes Made:
1. **`btn_gold_edit()`**:
   - Allows users to edit an existing gold entry.
   - A prompt is shown to input the new gold value.
   - The gold value is updated if the user provides a non-empty value.

2. **`btn_gold_delete()`**:
   - Enables users to delete a selected gold entry after confirming the action.
   - A confirmation dialog appears to ensure the user wants to remove the gold.

3. **Event Handling in `cb_load()`**:
   - Added an event listener to the `.rt-gold li` elements.
   - Prompts the user with options to either "edit" or "delete" the gold.
   - Calls the respective function (`btn_gold_edit` or `btn_gold_delete`) based on the user's choice.

#### Implementation Details:
- **Editing Gold**: 
  - When a user selects "edit", the current gold is displayed in a prompt, and they can modify it.
  - The updated gold is saved back to the corpus and updated in the UI.

- **Deleting Gold**:
  - When a user selects "delete", they are asked for confirmation before the gold entry is removed from the corpus.

#### Why This Change Is Important:
- This feature allows users to maintain and clean up gold entries, improving the flexibility and accuracy of the corpus management.
- It provides a more interactive and user-friendly way to modify the golds without needing to manually update files.

#### Related Issue:
- Closes #23
