### PR TITLE
addressed #23, now can remove gold in the web UI

### DIFF
--- a/apertium-regtest.py
+++ b/apertium-regtest.py
@@ -624,7 +624,10 @@ class Corpus:
         return list(set(changes))
     def set_gold(self, hsh, vals, step=None):
         blob = self.step(step)
-        blob['gold'][hsh] = vals
+        if vals:
+            blob['gold'][hsh] = vals
+        elif hsh in blob['gold']:
+            del blob['gold'][hsh]
         if not Corpus.flat:
             ensure_dir_exists('gold')
         save_gold(self.gold_name(blob['cmd']), blob['gold'])

--- a/static/regtest.css
+++ b/static/regtest.css
@@ -73,6 +73,16 @@ ul.rt-gold:before {
     font-weight: bold;
 }
 
+.rt-gold-item {
+	display: flex;
+	align-items: flex-start;
+	gap: 1ex;
+}
+
+.rt-gold-value {
+	flex: 1;
+}
+
 input.rt-gold-input-box {
     width: 75%;
 }

--- a/static/regtest.js
+++ b/static/regtest.js
@@ -476,9 +476,25 @@ function btn_gold_manual() {
 
 function make_gold_list(golds) {
 	let ul = '<ul class="list-group rt-gold">';
-	ul += golds.map(g => '<li class="list-group-item">'+esc_html(g)+'</li>').join('');
+	ul += golds.map(function(g) {
+		return '<li class="list-group-item rt-gold-item"><span class="rt-gold-value">'+esc_html(g)+'</span> <button tabindex="-1" type="button" class="btn btn-sm btn-outline-danger btnGoldRemove" title="remove this gold value">Remove</button></li>';
+	}).join('');
 	ul += '</ul>';
 	return ul;
+}
+
+function btn_gold_remove() {
+	let tr = $(this).closest('tr');
+	let c = tr.attr('data-corp');
+	let h = tr.attr('data-hash');
+	let s = tr.find('.nav-link.active').text();
+	let li = $(this).closest('li');
+	let gs = li.closest('.rt-gold').find('.rt-gold-value').map(function() {
+		return $(this).text();
+	}).get();
+	gs.splice(li.index(), 1);
+	let tid = toast('Removing Gold', 'Corpus '+c+' sentence '+h+' step '+s);
+	post({a: 'gold', c: c, h: h, s: s, gs: JSON.stringify(gs)}).done(function() { $(tid).toast('hide'); load(state._page); });
 }
 
 function btn_gold_manual_accept() {
@@ -1003,6 +1019,7 @@ function cb_load(rv) {
 	$('.btnGoldReplace').off().click(btn_gold_replace);
 	$('.btnGoldAdd').off().click(btn_gold_add);
 	$('.btnGoldManual').off().click(btn_gold_manual);
+	$('.rt-changes').off('click', '.btnGoldRemove').on('click', '.btnGoldRemove', btn_gold_remove);
 	$('.btnGoldManualAccept').off().click(btn_gold_manual_accept);
 	$('.btnGoldManualCancel').off().click(btn_gold_manual_cancel);
 	$('.btnAcceptUntil').off().click(btn_accept_until);


### PR DESCRIPTION
Implemented support for removing individual gold values from the web UI.

Here are the changes:

- I Added a `Remove` button next to each displayed gold value in the web interface.
- when clicked, the selected gold value is removed from the list and the remaining gold values are saved through the existing `gold` callback.
- if the last gold value for an input is removed, the backend now deletes that gold entry instead of saving an empty gold block.
- after removal, the current page reloads so gold-related filters such as “No Gold” and “Unmatched Gold” are recalculated.

Here is an example of how it looks in the web UI (I used Kickapoo [kic] as an example to test it) :

Before:
<img width="1681" height="431" alt="image" src="https://github.com/user-attachments/assets/f9193c6b-d152-479c-906e-53659c2847a6" />

After:
<img width="1665" height="429" alt="image" src="https://github.com/user-attachments/assets/f4beee11-791c-4405-9eef-1a6e0222011b" />

Closes #23